### PR TITLE
docs(demo): fixed for sending a changed html to Codepen

### DIFF
--- a/demo/src/components/HtmlExampleComponent.vue
+++ b/demo/src/components/HtmlExampleComponent.vue
@@ -21,10 +21,10 @@ const ngwMapAdapter = ref<string>(
 );
 
 const html = ref<string>(props.item.html || '');
-const iframeHtml = ref<string>(html.value);
+const editableHtml = ref<string>(html.value);
 const scrollAreaHeight = ref('calc(100% - 90px)');
 
-const dirt = computed(() => html.value !== iframeHtml.value);
+const dirt = computed(() => html.value !== editableHtml.value);
 
 const changeAdapter = () => {
   const ngwMaps = unref(props.item.ngwMaps);
@@ -33,7 +33,7 @@ const changeAdapter = () => {
     const exist = ngwMaps.find((x) => x.name === adapter);
     if (exist) {
       html.value = changeHtmlMapAdapter(html.value, exist, ngwMaps);
-      iframeHtml.value = html.value;
+      editableHtml.value = html.value;
     }
   }
 };
@@ -41,12 +41,12 @@ const changeAdapter = () => {
 watch([ngwMapAdapter], changeAdapter);
 
 const save = () => {
-  iframeHtml.value = html.value;
+  editableHtml.value = html.value;
 };
 
 const copy = async () => {
   try {
-    await navigator.clipboard.writeText(iframeHtml.value);
+    await navigator.clipboard.writeText(editableHtml.value);
     $q.notify({
       color: 'positive',
       position: 'top',
@@ -69,7 +69,7 @@ const copy = async () => {
     <HtmlExampleHeaderComponent
       v-model="ngwMapAdapter"
       v-model:scrollAreaHeight="scrollAreaHeight"
-      :html="iframeHtml"
+      :html="editableHtml"
       :item="item"
       :dirt="dirt"
       @save="save"
@@ -77,7 +77,7 @@ const copy = async () => {
     />
 
     <HtmlExampleIframeComponent
-      :html="iframeHtml"
+      :html="editableHtml"
       style="height: 400px; width: 100%"
     />
 
@@ -92,7 +92,7 @@ const copy = async () => {
       <HtmlExampleHeaderComponent
         v-model="ngwMapAdapter"
         v-model:scrollAreaHeight="scrollAreaHeight"
-        :html="iframeHtml"
+        :html="editableHtml"
         :item="item"
         :dirt="dirt"
         @save="save"
@@ -104,7 +104,7 @@ const copy = async () => {
       </q-scroll-area>
     </div>
     <div class="col">
-      <HtmlExampleIframeComponent :html="iframeHtml" />
+      <HtmlExampleIframeComponent :html="editableHtml" />
     </div>
   </div>
 </template>

--- a/demo/src/components/HtmlExampleComponent.vue
+++ b/demo/src/components/HtmlExampleComponent.vue
@@ -69,6 +69,7 @@ const copy = async () => {
     <HtmlExampleHeaderComponent
       v-model="ngwMapAdapter"
       v-model:scrollAreaHeight="scrollAreaHeight"
+      :html="iframeHtml"
       :item="item"
       :dirt="dirt"
       @save="save"
@@ -91,6 +92,7 @@ const copy = async () => {
       <HtmlExampleHeaderComponent
         v-model="ngwMapAdapter"
         v-model:scrollAreaHeight="scrollAreaHeight"
+        :html="iframeHtml"
         :item="item"
         :dirt="dirt"
         @save="save"

--- a/demo/src/components/HtmlExampleHeaderComponent.vue
+++ b/demo/src/components/HtmlExampleHeaderComponent.vue
@@ -10,6 +10,7 @@ const props = defineProps({
   scrollAreaHeight: { type: String },
   dirt: Boolean,
   item: { type: Object as PropType<TreeNode>, required: true },
+  html: { type: String, required: true },
 });
 
 const emit = defineEmits([
@@ -111,7 +112,7 @@ onMounted(async () => {
             title="Copy code"
             @click="() => emit('copy')"
           />
-          <SendToCodepen class="col" :item="item" />
+          <SendToCodepen class="col" :item="item" :html="html" />
         </div>
       </div>
     </div>

--- a/demo/src/components/SendToCodepen.vue
+++ b/demo/src/components/SendToCodepen.vue
@@ -25,6 +25,7 @@ interface PenData {
 
 const props = defineProps({
   item: { type: Object as PropType<TreeNode>, required: true },
+  html: { type: String, required: true },
 });
 
 const tabLeft = (text: string) => {
@@ -88,8 +89,8 @@ const parseHtml = (html: string): PenData => {
 };
 
 const value = computed(() => {
-  if (props.item.html) {
-    return JSON.stringify(parseHtml(props.item.html))
+  if (props.html) {
+    return JSON.stringify(parseHtml(props.html))
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&apos;');
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -543,7 +543,7 @@ __metadata:
 
 "@nextgis/build-tools@file:../build-tools::locator=%40nextgis%2Fcesium-map-adapter%40workspace%3Apackages%2Fcesium-map-adapter":
   version: 2.0.2
-  resolution: "@nextgis/build-tools@file:../build-tools#../build-tools::hash=5b9619&locator=%40nextgis%2Fcesium-map-adapter%40workspace%3Apackages%2Fcesium-map-adapter"
+  resolution: "@nextgis/build-tools@file:../build-tools#../build-tools::hash=aeda08&locator=%40nextgis%2Fcesium-map-adapter%40workspace%3Apackages%2Fcesium-map-adapter"
   dependencies:
     "@nextgis/eslint-config": ^2.0.2
     "@rollup/plugin-alias": ^5.1.0
@@ -570,13 +570,13 @@ __metadata:
     rollup-plugin-terser: ^7.0.2
     rollup-plugin-typescript2: ^0.36.0
     typescript: ~5.1
-  checksum: d1466bc7ef415bea77eb94942f93e1d4d2dffb2765b46c824037277cec346826810858552287c2fed4ad74f89159cb33f065325d70acc30b2fd5e9936b91f299
+  checksum: a96459abc4088728532611fe0bdb3333e48fd8c60261d15f45384f0c1f53986ee1f14cb62edb365699f2ae4fbb6da529952d014632d334fb23652aafb07b3270
   languageName: node
   linkType: hard
 
 "@nextgis/build-tools@file:../build-tools::locator=%40nextgis%2Fngw-cesium%40workspace%3Apackages%2Fngw-cesium":
   version: 2.0.2
-  resolution: "@nextgis/build-tools@file:../build-tools#../build-tools::hash=5b9619&locator=%40nextgis%2Fngw-cesium%40workspace%3Apackages%2Fngw-cesium"
+  resolution: "@nextgis/build-tools@file:../build-tools#../build-tools::hash=aeda08&locator=%40nextgis%2Fngw-cesium%40workspace%3Apackages%2Fngw-cesium"
   dependencies:
     "@nextgis/eslint-config": ^2.0.2
     "@rollup/plugin-alias": ^5.1.0
@@ -603,7 +603,7 @@ __metadata:
     rollup-plugin-terser: ^7.0.2
     rollup-plugin-typescript2: ^0.36.0
     typescript: ~5.1
-  checksum: d1466bc7ef415bea77eb94942f93e1d4d2dffb2765b46c824037277cec346826810858552287c2fed4ad74f89159cb33f065325d70acc30b2fd5e9936b91f299
+  checksum: a96459abc4088728532611fe0bdb3333e48fd8c60261d15f45384f0c1f53986ee1f14cb62edb365699f2ae4fbb6da529952d014632d334fb23652aafb07b3270
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
When HTML is dynamically modified   while the page is running   (for example, default library "Leaflet" is changed for "OpenLayers"),   the updated HTML content is sent to CodePen. 
Also, const "iframeHtml" is replaced with "editableHtml".